### PR TITLE
Update SinglyLinkedList.hpp

### DIFF
--- a/SinglyLinkedList/SinglyLinkedList.hpp
+++ b/SinglyLinkedList/SinglyLinkedList.hpp
@@ -160,7 +160,7 @@ public:
 
 	};
 	
-	ConstSllIterator begin()
+	SllIterator begin()
 	{
 		return SllIterator(head);
 	}
@@ -317,7 +317,11 @@ typename SinglyLinkedList<T>::SllIterator SinglyLinkedList<T>::insertAfter(const
 
 	newNode->next = itNode->next;
 	itNode->next = newNode;
-    size++;
+    	size++;
+	if (itNode == tail)
+    	{
+           tail = newNode;
+   	}
 	return SinglyLinkedList<T>::SllIterator(newNode);
 }
 
@@ -325,7 +329,7 @@ typename SinglyLinkedList<T>::SllIterator SinglyLinkedList<T>::insertAfter(const
 template <typename T>
 typename SinglyLinkedList<T>::SllIterator SinglyLinkedList<T>::removeAfter(const typename SinglyLinkedList<T>::ConstSllIterator& it)
 {
-    if(it == end() || getSize() == 1)
+    if(it == end() || it.currentElementPtr->next == nullptr)
         return end();
         
 	Node* toDelete = (it + 1).currentElementPtr;


### PR DESCRIPTION
във функцията remove_after мисля, че трябва да има проверка if (it.currentElementPtr->next == nullptr), защото ако имаме списък с два елемента и преместим итератора в края на списъка, той ще се опита да получи достъп до toDelete->next, което прави проблем. Във функцията insert_after, ако вмъкнем след tail и след това се опитаме да push_back-нем друг елемент губим елемента, които сме insert-нали затова ако itNode == tail, трябва да насочим tail към новия node.