### PR TITLE
fixed errase memory leak

### DIFF
--- a/Vector/vector/vector.hpp
+++ b/Vector/vector/vector.hpp
@@ -342,18 +342,20 @@ void vector<T, Allocator>::erase(const_iterator first, const_iterator last)
 
 	int begin_offset = first - begin();
 	int end_offset = last - begin();
+	
+	size_t construct_idx = begin_offset;
 
 	if (last != c_end())
 	{
-		size_t construct_idx = begin_offset;
+		
 		for (size_t i = end_offset; i < size(); i++)
 		{
 			_allocator.construct(&_data[construct_idx], std::move(_data[i]));
 			++construct_idx;
 		}
 	}
-
-	for (size_t i = end_offset; i < size(); i++)
+	//трием излишъка, след последния нужен елемент, който вече сме преместили
+	for (size_t i = construct_idx; i < size(); i++)
 		_allocator.destroy(&_data[i]);
 	
 	_size -= deleted_count;


### PR DESCRIPTION
If we had for instance  {"a", "b", "c", "d", "e"}
and then we call: erase(v.begin() + 1, v.end() - 1); it would turn it into [a, e, c, d, e]
and then delete after end_offset. and leave us with [a, e, c, d] isntead of [a,e] but we still do size-=3.  c,d are still there even beyond our available size. Fixed: just delete after the last constructed element.