### PR TITLE
Updated Cycling Problem in HashSet.hpp

### DIFF
--- a/LinearProbingHash/Set/HashSet.hpp
+++ b/LinearProbingHash/Set/HashSet.hpp
@@ -89,6 +89,7 @@ template <class KeyType, class Hasher>
 void HashSet<KeyType, Hasher>::remove(const KeyType& key)
 {
     int index = hasher(key) % data.size();
+    int start=index;
     while (data[index].data.has_value())
     {
         if (!data[index].tombstone && *data[index].data == key)
@@ -98,6 +99,7 @@ void HashSet<KeyType, Hasher>::remove(const KeyType& key)
             break;
         }
         (index += k) %= data.size();
+        if(index==start) return; //nothing to remove
     }
 }
 
@@ -105,6 +107,7 @@ template <class KeyType, class Hasher>
 typename HashSet<KeyType, Hasher>::ConstIterator HashSet<KeyType, Hasher>::get(const KeyType& key) const
 {
     int index = hasher(key) % data.size();
+    int start=index;
     while (data[index].data.has_value())
     {
         if (!data[index].tombstone && *data[index].data == key)
@@ -112,6 +115,7 @@ typename HashSet<KeyType, Hasher>::ConstIterator HashSet<KeyType, Hasher>::get(c
             return ConstIterator(index, *this);
         }
         (index += k) %= data.size();
+        if(index==start) break; // starts cycling, thus we break; 
     }
     return cend();
 }


### PR DESCRIPTION
if we had this code for example, it wont stop looking to remove 6 int main() {

    HashSet<int> s(6, 2);

    s.add(0);
    s.add(2);
    s.add(4);
    s.remove(0);
    s.remove(2);
    s.remove(4);

   
   s.remove(6);

    // Никога няма да стигнем дотук 
    std::cout << "ALl done" << "\n";
    return 0;
}